### PR TITLE
Always be the first option

### DIFF
--- a/copytoclipboard2.js
+++ b/copytoclipboard2.js
@@ -6,8 +6,8 @@
 
 let copyTextCount = 0;
 (async function copyText() {
-    if (!Spicetify && copyTextCount < 200) {
-        setTimeout(copyText, 300);
+    if (!Spicetify && copyTextCount < 1000) {
+        setTimeout(copyText, 10);
         copyTextCount++;
         return;
     }


### PR DESCRIPTION
Some times `Copy Text` will be listed 2nd or 3rd now it will be on top always